### PR TITLE
Sync all pairings with rank each time.

### DIFF
--- a/HandleQueuedResults.py
+++ b/HandleQueuedResults.py
@@ -251,7 +251,9 @@ class HandleQueuedResults(webapp.RequestHandler):
                 if not hasattr(pairings[i],"Alive"):
                     pairings[i].Alive = True
                 
-                if pairings[i].Alive and pairings[i].Name not in scores:
+                if pairings[i].Name in scores:
+                    pairings[i].Alive = True
+                else:
                     pairings[i].Alive = False
             
                 i += 1

--- a/HandleQueuedResults.py
+++ b/HandleQueuedResults.py
@@ -248,8 +248,6 @@ class HandleQueuedResults(webapp.RequestHandler):
                 if pairings[i].Name == b.Name:
                     pairings.pop(i)
                     continue
-                if not hasattr(pairings[i],"Alive"):
-                    pairings[i].Alive = True
                 
                 if pairings[i].Name in scores:
                     pairings[i].Alive = True


### PR DESCRIPTION
This PR reduces battles needed from ~1,000,000 to ~1,000 when it comes to restore the rumble. Currently when a battle is submitted, only 1 pairing is restored to active. This PR enables it to set all current pairings to active. 